### PR TITLE
Fixed chart and coloured cells in Orders to Fulfill report

### DIFF
--- a/bnovate/bnovate/report/orders_to_fulfill/orders_to_fulfill.js
+++ b/bnovate/bnovate/report/orders_to_fulfill/orders_to_fulfill.js
@@ -11,4 +11,10 @@ frappe.query_reports["Orders to Fulfill"] = {
             "default" : 1
         },
 	]
+	/*,
+	"formatter": function (value, row, column, data, default_formatter) {
+		console.log(value, row, column, data, default_formatter);
+		return default_formatter(value, row, column, data);
+	}
+	*/
 };


### PR DESCRIPTION
- Bar chart values are fixed: they now correctly display the sum of all items in the week, instead of the first row in the data.
- Week numbers and shipping dates are coloured in alternating fashion for easier differentiation.

Could you please merge this in our live instance?