### PR TITLE
Add time tracking to work order execution

### DIFF
--- a/bnovate/bnovate/page/work_order_execution/time_tracking.html
+++ b/bnovate/bnovate/page/work_order_execution/time_tracking.html
@@ -1,0 +1,7 @@
+<div style="padding-top: 25px">
+    {% if timing_started %}
+    <button class="btn btn-block btn-danger stop-timer"><i class="fa fa-clock-o"></i> Stop timer</button>
+    {% else %}
+    <button class="btn btn-block btn-success start-timer"><i class="fa fa-clock-o"></i> Start timer</button>
+    {% endif %}
+</div>

--- a/bnovate/bnovate/page/work_order_execution/work_order_execution.js
+++ b/bnovate/bnovate/page/work_order_execution/work_order_execution.js
@@ -650,6 +650,30 @@ frappe.pages['work-order-execution'].on_page_load = function (wrapper) {
 	frappe.bnovate.work_order_execution.submit_doc = submit_doc;
 
 
+	async function start_time_log(work_order_id) {
+		let resp = await frappe.call({
+			method: "bnovate.bnovate.page.work_order_execution.work_order_execution.start_log",
+			args: {
+				work_order_id,
+			}
+		});
+		return resp.message;
+	}
+	frappe.bnovate.work_order_execution.start_time_log = start_time_log;
+
+
+	async function stop_time_log(work_order_id) {
+		let resp = await frappe.call({
+			method: "bnovate.bnovate.page.work_order_execution.work_order_execution.stop_log",
+			args: {
+				work_order_id,
+			}
+		});
+		return resp.message;
+	}
+	frappe.bnovate.work_order_execution.stop_time_log = stop_time_log;
+
+
 	async function fetch_item_details(item_codes) {
 		// Fetch item detail docs, store in locals["Items"].
 		let promises = [];

--- a/bnovate/bnovate/page/work_order_execution/work_order_execution.py
+++ b/bnovate/bnovate/page/work_order_execution/work_order_execution.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2017-2022, bnovate, libracore and contributors
+#
+
+# These methods require some custom fields on work orders:
+#
+# - time_log: table of "Work Order Time Log" child items. These have a datetime start_time and end_time field, and a float duration field.
+#           start_time is mandatory, all can be changed after submit.
+# - total_time: float, total duration in minutes.
+#
+
+from __future__ import unicode_literals
+import frappe
+from frappe import throw, _
+import hashlib
+from datetime import datetime, timedelta
+
+@frappe.whitelist()
+def start_log(work_order_id):
+    """ Add a row to time tracking with current time as start time. """
+    wo = frappe.get_doc("Work Order", work_order_id)
+    # Check if an open time log exists. If so, raise error. Should pause first.
+    if None in [ row.end_time for row in wo.time_log ]:
+        return frappe.msgprint("Time logging has already started on this work order.", raise_exception=True)
+    row = wo.append('time_log', {
+        'start_time': datetime.now(),
+    })
+    wo.save()
+    frappe.db.commit()
+    return
+
+@frappe.whitelist()
+def stop_log(work_order_id):
+    """ Update end time on current time log, calculate duration"""
+    wo = frappe.get_doc("Work Order", work_order_id)
+    for row in wo.time_log:
+        if row.end_time is None:
+            row.end_time = datetime.now()
+            row.duration = (row.end_time - row.start_time).total_seconds() / 60
+
+            wo.save()
+            frappe.db.commit()
+            return
+
+    # If we reached this point, no logs were open
+    frappe.msgprint("Time logging hasn't been started yet, therefore it can't be stopped.", raise_exception=True)
+
+
+def calculate_total_time(doc, method=None):
+    wo = doc
+    for row in wo.time_log:
+        if row.end_time is None:
+            continue
+        row.duration = (row.end_time - row.start_time).total_seconds() / 60
+
+    wo.total_time = sum([row.duration for row in wo.time_log if row.duration is not None])
+    print("Calculating total time for WO:", wo.total_time)
+    # wo_doc.save()
+    # frappe.db.commit()
+
+#TODO: method that calculates total time and time per part. Use frappe hooks to call when WO is saved.
+# See https://youtu.be/GGdWRe-aoxA?t=383

--- a/bnovate/bnovate/page/work_order_execution/work_order_execution.py
+++ b/bnovate/bnovate/page/work_order_execution/work_order_execution.py
@@ -5,14 +5,14 @@
 # These methods require some custom fields on work orders:
 #
 # - time_log: table of "Work Order Time Log" child items. These have a datetime start_time and end_time field, and a float duration field.
-#           start_time is mandatory, all can be changed after submit.
-# - total_time: float, total duration in minutes.
+#           start_time is mandatory, duration is read-only. All can be changed after submit.
+# - total_time: float, total duration in minutes. Read only, allowed on submit.
 #
 
 from __future__ import unicode_literals
 import frappe
 from frappe import throw, _
-import hashlib
+from frappe.utils import get_datetime
 from datetime import datetime, timedelta
 
 @frappe.whitelist()
@@ -33,10 +33,9 @@ def start_log(work_order_id):
 def stop_log(work_order_id):
     """ Update end time on current time log, calculate duration"""
     wo = frappe.get_doc("Work Order", work_order_id)
-    for row in wo.time_log:
+    for row in wo.time_log[::-1]: # Finish most recent row if there happens to be several
         if row.end_time is None:
             row.end_time = datetime.now()
-            row.duration = (row.end_time - row.start_time).total_seconds() / 60
 
             wo.save()
             frappe.db.commit()
@@ -47,16 +46,31 @@ def stop_log(work_order_id):
 
 
 def calculate_total_time(doc, method=None):
+    """ Calculate total time per WO and per produced part. Called by hooks.py  """
     wo = doc
     for row in wo.time_log:
         if row.end_time is None:
-            continue
-        row.duration = (row.end_time - row.start_time).total_seconds() / 60
+            row.duration = 0
+        else:
+            row.duration = (get_datetime(row.end_time) - get_datetime(row.start_time)).total_seconds() / 60
+        row.db_set("duration", row.duration)
 
     wo.total_time = sum([row.duration for row in wo.time_log if row.duration is not None])
-    print("Calculating total time for WO:", wo.total_time)
-    # wo_doc.save()
-    # frappe.db.commit()
+    wo.time_per_unit = 0 if wo.produced_qty == 0 else wo.total_time / wo.produced_qty
+    wo.db_set("total_time", wo.total_time)
+    # If we wanted time per unit, we would need hooks on Stock Entry, after submit and after cancel.
+    wo.db_set("time_per_unit", wo.time_per_unit)
+
+def update_work_order_unit_time(stock_entry, method=None):
+    """ Re-calculate per-unit time on work orders after a stock entry has changed produced qty.
+    
+    Called by hooks.py
+    """
+    if stock_entry.purpose != "Manufacture":
+        return
+
+    wo = frappe.get_doc("Work Order", stock_entry.work_order)
+    calculate_total_time(wo)
 
 #TODO: method that calculates total time and time per part. Use frappe hooks to call when WO is saved.
 # See https://youtu.be/GGdWRe-aoxA?t=383

--- a/bnovate/hooks.py
+++ b/bnovate/hooks.py
@@ -79,13 +79,16 @@ app_include_js = "/assets/bnovate/js/bnovate_common.js"
 # ---------------
 # Hook on document methods and events
 
-# doc_events = {
+doc_events = {
 # 	"*": {
 # 		"on_update": "method",
 # 		"on_cancel": "method",
 # 		"on_trash": "method"
 #	}
-# }
+    "Work Order": {
+        "on_update": "bnovate.bnovate.page.work_order_execution.work_order_execution.calculate_total_time",
+    }
+}
 
 # Scheduled Tasks
 # ---------------

--- a/bnovate/hooks.py
+++ b/bnovate/hooks.py
@@ -86,7 +86,12 @@ doc_events = {
 # 		"on_trash": "method"
 #	}
     "Work Order": {
-        "on_update": "bnovate.bnovate.page.work_order_execution.work_order_execution.calculate_total_time",
+        "before_save": "bnovate.bnovate.page.work_order_execution.work_order_execution.calculate_total_time",
+        "on_update_after_submit": "bnovate.bnovate.page.work_order_execution.work_order_execution.calculate_total_time",
+    },
+    "Stock Entry": {
+        "on_submit": "bnovate.bnovate.page.work_order_execution.work_order_execution.update_work_order_unit_time",
+        "on_cancel": "bnovate.bnovate.page.work_order_execution.work_order_execution.update_work_order_unit_time",
     }
 }
 


### PR DESCRIPTION
- Frontend: added buttons to start and stock timer
- Work orders: 
  - added table of time logs (manually using customize form and doctype)
  - new methods to create rows in the time log
- Hooks: calculate duration based on time log, triggered when updating work order or related stock entry